### PR TITLE
Add LEDSubsystem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2020.2.2"
+    id "edu.wpi.first.GradleRIO" version "2020.3.2"
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -35,4 +35,8 @@ public final class Constants {
   // Pneumatic solenoid addresses
 
   // Brushed PWM addresses
+
+  // LEDs
+  public static final int ADDRESSABLE_LED_PWM_ADDRESS = 3;
+  public static final int ADDRESSABLE_LED_LENGTH = 50;
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -37,6 +37,6 @@ public final class Constants {
   // Brushed PWM addresses
 
   // LEDs
-  public static final int ADDRESSABLE_LED_PWM_ADDRESS = 3;
+  public static final int ADDRESSABLE_LED_PWM_ADDRESS = 5;
   public static final int ADDRESSABLE_LED_LENGTH = 50;
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -44,7 +44,6 @@ public class RobotContainer {
 
   public final LEDSubsystem ledSubsystem = new LEDSubsystem();
 
-  public final DriveCommand driveCommand = new DriveCommand(driveSubsystem);
   private final ControllerBase mainController = new ControllerBase(xbox, f310);
 
   private final JoystickButton intakeRollerFwdButton = new JoystickButton(f310, 4/* LeftBumper */);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,6 +12,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.commands.DriveCommand;
 import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.IntakeSubsystem;
+import frc.robot.subsystems.LEDSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 import frc.robot.controllers.ControllerBase;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -28,6 +29,8 @@ public class RobotContainer {
   public final DriveSubsystem driveSubsystem = new DriveSubsystem();
   public final ShooterSubsystem shooterSubsystem = new ShooterSubsystem();
   public final IntakeSubsystem IntakeSubsystem = new IntakeSubsystem();
+
+  public final LEDSubsystem ledSubsystem = new LEDSubsystem();
 
   public final DriveCommand driveCommand = new DriveCommand(driveSubsystem);
 

--- a/src/main/java/frc/robot/subsystems/LEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LEDSubsystem.java
@@ -1,0 +1,61 @@
+package frc.robot.subsystems;
+
+import org.usfirst.frc.team4999.lights.AddressableLEDDisplay;
+import org.usfirst.frc.team4999.lights.AnimationCoordinator;
+import org.usfirst.frc.team4999.lights.Animator;
+import org.usfirst.frc.team4999.lights.Color;
+import org.usfirst.frc.team4999.lights.animations.*;
+
+import edu.wpi.first.wpilibj.AddressableLED;
+import edu.wpi.first.wpilibj.AddressableLEDBuffer;
+
+import static frc.robot.Constants.*;
+
+public class LEDSubsystem {
+  private AddressableLEDDisplay display;
+  private Animator animator;
+  private AnimationCoordinator coordinator;
+
+  public AddressableLED test;
+
+  private static final String BASE_ANIMATION_KEY = "BASE_ANIMATION";
+  private static final int BASE_ANIMATION_PRIORITY = 0;
+
+  private static Color[] rainbowcolors = { new Color(139, 0, 255), Color.BLUE, Color.GREEN, Color.YELLOW,
+      new Color(255, 127, 0), Color.RED };
+
+  public final Animation rainbow = new AnimationSequence(new Animation[] { Snake.rainbowSnake(70),
+      Fade.rainbowFade(100, 20), new Bounce(Color.WHITE, rainbowcolors, 40, 50), new Stack(rainbowcolors, 50, 40),
+      new BounceStack(rainbowcolors, 20, 40) }, new int[] { 5000, 5000, 10000, 10000, 10000 });
+
+  public LEDSubsystem() {
+
+    try {
+      display = new AddressableLEDDisplay(ADDRESSABLE_LED_PWM_ADDRESS, ADDRESSABLE_LED_LENGTH);
+      animator = new Animator(display);
+      coordinator = new AnimationCoordinator(animator);
+
+      setBaseAnimation(rainbow);
+    } catch (Exception e) {
+      e.printStackTrace();
+      coordinator = null;
+      if (animator != null) {
+        animator.stopAnimation();
+      }
+      animator = null;
+      if (display != null) {
+        display.stop();
+      }
+      display = null;
+    }
+
+  }
+
+  public void setBaseAnimation(Animation animation) {
+    if (coordinator != null) {
+      coordinator.popAnimation(BASE_ANIMATION_KEY);
+      coordinator.pushAnimation(BASE_ANIMATION_KEY, animation, BASE_ANIMATION_PRIORITY, false);
+    }
+  }
+
+}

--- a/vendordeps/neopixel-leds.json
+++ b/vendordeps/neopixel-leds.json
@@ -1,7 +1,7 @@
 {
     "fileName": "neopixel-leds.json",
     "name": "Neopixel_LEDs",
-    "version": "1.2",
+    "version": "1.3",
     "uuid": "7e31ef33-cc0c-4dd3-8bdd-dae39e2b5d5d",
     "mavenUrls": [
         "https://raw.githubusercontent.com/momentumfrc/Momentum-Tools/master/mvn-repo"
@@ -11,7 +11,7 @@
         {
             "groupId": "org.usfirst.frc.team4999",
             "artifactId": "neopixel-leds",
-            "version": "1.2"
+            "version": "1.3"
         }
     ],
     "jniDependencies": [],


### PR DESCRIPTION
LEDSubsystem manages the neopixels.

It should be extended with methods as needed to show and hide different status "overlays" to convey information to the driver. This is very similar to the [NeoPixels](https://github.com/momentumfrc/2019DeepSpace/blob/master/2019RobotCodeDeepSpace/src/main/java/frc/robot/utils/NeoPixels.java) class from last year.

The functionality can be simulated by running the "WPILib: Simulate Robot Code on Desktop" command in VSCode, enabling halsim_gui.dll, then enabling the Addressable LEDs dialogue (under Window->Addressable LEDs). 