### PR TITLE
Add MoPrefsKey enum

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -26,6 +26,7 @@ import frc.robot.subsystems.conditioners.CurvesConditioner;
 import frc.robot.subsystems.conditioners.DeadzoneConditioner;
 import frc.robot.subsystems.conditioners.SpeedLimitConditioner;
 import frc.robot.utils.MoPrefs;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 import frc.robot.controllers.ControllerBase;
 
 import edu.wpi.first.wpilibj.GenericHID;
@@ -99,20 +100,22 @@ public class RobotContainer {
 
   private final DriveCommand driveCommand = new DriveCommand(falconDriveSubsystem, mainController, driveConditioner);
   // Starts shooting and turns on the limelight.
-  private final Command shootCommand = new RunCommand(() -> shooterSubsystem.shoot(MoPrefs.getShooterHoodSetpoint()),
-      shooterSubsystem).alongWith(new RunCommand(limelight::lightsOn, limelight));
+  private final Command shootCommand = new RunCommand(
+      () -> shooterSubsystem.shoot(MoPrefs.get(MoPrefsKey.SHOOTER_HOOD_SETPOINT)), shooterSubsystem)
+          .alongWith(new RunCommand(limelight::lightsOn, limelight));
   // Deploys the shooter hood, starts shooting, and runs the intake.
   // 10 seconds later, all of those stop, and then drive off of the initiation
   // line.
   private final Command shootFromLine = new ParallelCommandGroup(
-      new RunCommand(() -> shooterSubsystem.shoot(MoPrefs.getShooterHoodSetpoint()), shooterSubsystem).withTimeout(10),
+      new RunCommand(() -> shooterSubsystem.shoot(MoPrefs.get(MoPrefsKey.SHOOTER_HOOD_SETPOINT)), shooterSubsystem)
+          .withTimeout(10),
       new RunCommand(intakeSubsystem::runIntakeFwd, intakeSubsystem).withTimeout(10))
           .andThen(new RunCommand(() -> falconDriveSubsystem.drive(0.5, 0), falconDriveSubsystem));
   // Drives forward to the wall, then starts shooting at a different angle than
   // normal(one tailored for shooting up against the wall)
   private final Command shootFromWall = new RunCommand(() -> falconDriveSubsystem.drive(0.5, 0)).withTimeout(5).andThen(
-      new ParallelCommandGroup(
-          new RunCommand(() -> shooterSubsystem.shoot(MoPrefs.getShootFromWallHoodSetpoint()), shooterSubsystem)),
+      new ParallelCommandGroup(new RunCommand(
+          () -> shooterSubsystem.shoot(MoPrefs.get(MoPrefsKey.SHOOT_FROM_WALL_HOOD_SETPOINT)), shooterSubsystem)),
       new RunCommand(storageSubsystem::run, storageSubsystem));
 
   private final Command driveToWall = new RunCommand(() -> falconDriveSubsystem.drive(0.5, 0)).withTimeout(5);

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.VictorSP;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.utils.MoPrefs;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 
 public class ClimberSubsystem extends SubsystemBase {
   private final VictorSP climberSP = new VictorSP(Constants.CLIMBER_VICTORSP_PWM_CHAN);
@@ -46,7 +47,7 @@ public class ClimberSubsystem extends SubsystemBase {
   }
 
   public void climb() {
-    if (!reliableZero || encoder.get() > MoPrefs.getClimberEncoderLimit())
+    if (!reliableZero || encoder.get() > MoPrefs.get(MoPrefsKey.CLIMBER_ENCODER_LIMIT))
       stop();
     else
       climberSP.set(CLIMB);

--- a/src/main/java/frc/robot/subsystems/FalconDriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/FalconDriveSubsystem.java
@@ -16,6 +16,7 @@ import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import edu.wpi.first.wpilibj.util.Units;
 import frc.robot.utils.MoPrefs;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
@@ -172,11 +173,11 @@ public class FalconDriveSubsystem extends DriveSubsystem {
 
   // Updates the PID constants stored in each Talon FX from MoPrefs
   private void updatePIDConstants() {
-    double kP = MoPrefs.getDriveKP();
-    double kI = MoPrefs.getDriveKI();
-    double kD = MoPrefs.getDriveKD();
-    int kIZ = (int) MoPrefs.getDriveKIZ();
-    double kFF = MoPrefs.getDriveKFF();
+    double kP = MoPrefs.get(MoPrefsKey.DRIVE_KP);
+    double kI = MoPrefs.get(MoPrefsKey.DRIVE_KI);
+    double kD = MoPrefs.get(MoPrefsKey.DRIVE_KD);
+    int kIZ = (int) MoPrefs.get(MoPrefsKey.DRIVE_KIZ);
+    double kFF = MoPrefs.get(MoPrefsKey.DRIVE_KFF);
     leftFront.config_kP(0, kP);
     leftFront.config_kI(0, kI);
     leftFront.config_kD(0, kD);

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -17,6 +17,7 @@ import frc.robot.Constants;
 import frc.robot.utils.MoPrefs;
 import frc.robot.utils.MoUtils;
 import frc.robot.utils.SafeSP;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 
 public class IntakeSubsystem extends SubsystemBase {
 
@@ -54,15 +55,15 @@ public class IntakeSubsystem extends SubsystemBase {
   }
 
   public void runIntakeFwd() {
-    setMotorsWithRamp(MoPrefs.getIntakeRollerSetpoint());
+    setMotorsWithRamp(MoPrefs.get(MoPrefsKey.INTAKE_ROLLER_SETPOINT));
   }
 
   public void runIntakeRvs() {
-    setMotorsWithRamp(-1 * MoPrefs.getIntakeRollerSetpoint());
+    setMotorsWithRamp(-1 * MoPrefs.get(MoPrefsKey.INTAKE_ROLLER_SETPOINT));
   }
 
   private void setMotorsWithRamp(double power) {
-    double currPower = MoUtils.rampMotor(power, lastPower, MoPrefs.getIntakeRollerAccRamp());
+    double currPower = MoUtils.rampMotor(power, lastPower, MoPrefs.get(MoPrefsKey.INTAKE_ROLLER_ACC_RAMP));
     lastPower = currPower;
     intakeSP.set(currPower);
     intakeSP2.set(currPower);

--- a/src/main/java/frc/robot/subsystems/ShooterHoodSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterHoodSubsystem.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.utils.MoPrefs;
 import frc.robot.utils.SimmableCANSparkMax;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -71,7 +72,7 @@ public class ShooterHoodSubsystem extends SubsystemBase {
   // Raises the hood to its setpoint using position PID.
   public void deployHood() {
     if (reliableZero) {
-      hoodPID.setReference(MoPrefs.getShooterHoodSetpoint(), ControlType.kPosition, 0);
+      hoodPID.setReference(MoPrefs.get(MoPrefsKey.SHOOTER_HOOD_SETPOINT), ControlType.kPosition, 0);
     } else {
       hoodNEO.set(SAFE_STOW_SPEED);
     }
@@ -103,7 +104,8 @@ public class ShooterHoodSubsystem extends SubsystemBase {
     // If the current position is in within +-positionTolerance of the setpoint,
     // return true
     // Otherwise, return false
-    return Math.abs(MoPrefs.getShooterHoodSetpoint() - getHoodPos()) < MoPrefs.getShooterHoodPositionTolerance();
+    return Math.abs(MoPrefs.get(MoPrefsKey.SHOOTER_HOOD_SETPOINT) - getHoodPos()) < MoPrefs
+        .get(MoPrefsKey.SHOOTER_HOOD_POSITION_TOLERANCE);
   }
 
   public boolean isHoodReady() {

--- a/src/main/java/frc/robot/subsystems/ShooterHoodSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterHoodSubsystem.java
@@ -116,14 +116,14 @@ public class ShooterHoodSubsystem extends SubsystemBase {
    * Update PID constants from MoPrefs
    */
   private void updatePidConstants() {
-    hoodPID.setP(MoPrefs.getHoodKP());
-    hoodPID.setI(MoPrefs.getHoodKI());
-    hoodPID.setD(MoPrefs.getHoodKD());
-    hoodPID.setIZone(MoPrefs.getHoodKIZ());
-    hoodPID.setFF(MoPrefs.getHoodKFF());
-    double outRange = MoPrefs.getHoodOutRange();
+    hoodPID.setP(MoPrefs.get(MoPrefsKey.HOOD_KP));
+    hoodPID.setI(MoPrefs.get(MoPrefsKey.HOOD_KI));
+    hoodPID.setD(MoPrefs.get(MoPrefsKey.HOOD_KD));
+    hoodPID.setIZone(MoPrefs.get(MoPrefsKey.HOOD_KIZ));
+    hoodPID.setFF(MoPrefs.get(MoPrefsKey.HOOD_KFF));
+    double outRange = MoPrefs.get(MoPrefsKey.HOOD_OUT_RANGE);
     hoodPID.setOutputRange(-outRange, outRange);
-    hoodPID.setSmartMotionAllowedClosedLoopError(MoPrefs.getHoodAllowedErr(), 0);
+    hoodPID.setSmartMotionAllowedClosedLoopError(MoPrefs.get(MoPrefsKey.HOOD_ALLOWED_ERR), 0);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -155,11 +155,11 @@ public class ShooterSubsystem extends SubsystemBase {
   }
 
   private void updatePIDConstants() {
-    shooterPIDRight.setP(MoPrefs.getShooterKP(), 0);
-    shooterPIDRight.setI(MoPrefs.getShooterKI(), 0);
-    shooterPIDRight.setD(MoPrefs.getShooterKD(), 0);
-    shooterPIDRight.setIZone(MoPrefs.getShooterKIZ(), 0);
-    shooterPIDRight.setFF(MoPrefs.getShooterKFF(), 0);
+    shooterPIDRight.setP(MoPrefs.get(MoPrefsKey.SHOOTER_KP), 0);
+    shooterPIDRight.setI(MoPrefs.get(MoPrefsKey.SHOOTER_KI), 0);
+    shooterPIDRight.setD(MoPrefs.get(MoPrefsKey.SHOOTER_KD), 0);
+    shooterPIDRight.setIZone(MoPrefs.get(MoPrefsKey.SHOOTER_KIZ), 0);
+    shooterPIDRight.setFF(MoPrefs.get(MoPrefsKey.SHOOTER_KFF), 0);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -26,6 +26,7 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import frc.robot.Constants;
 import frc.robot.utils.MoPrefs;
 import frc.robot.utils.SimmableCANSparkMax;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 
 public class ShooterSubsystem extends SubsystemBase {
   /**
@@ -108,7 +109,7 @@ public class ShooterSubsystem extends SubsystemBase {
     // deploy hood
     // run gate if both of "" are good
 
-    double pidSetpoint = MoPrefs.getShooterPIDSetpoint();
+    double pidSetpoint = MoPrefs.get(MoPrefsKey.SHOOTER_PID_SETPOINT);
 
     if (enablePID) {
       shooterPIDRight.setReference(pidSetpoint, ControlType.kVelocity);
@@ -119,7 +120,7 @@ public class ShooterSubsystem extends SubsystemBase {
     shooterHood.setHoodPosition(hoodSetpoint);
 
     if (shooterHood.isHoodReady() && isFlywheelReady()) {
-      shooterGate.set(MoPrefs.getShooterGateSetpoint());
+      shooterGate.set(MoPrefs.get(MoPrefsKey.SHOOTER_GATE_SETPOINT));
     } else {
       shooterGate.set(0);
     }
@@ -136,7 +137,7 @@ public class ShooterSubsystem extends SubsystemBase {
     // reverse gate
     // reverse shooter wheel
     leader_shooterMAXRight.set(-0.2);
-    shooterGate.set(-1 * MoPrefs.getShooterGateSetpoint());
+    shooterGate.set(-1 * MoPrefs.get(MoPrefsKey.SHOOTER_GATE_SETPOINT));
   }
 
   /**
@@ -149,8 +150,8 @@ public class ShooterSubsystem extends SubsystemBase {
   }
 
   private boolean isFlywheelReady() {
-    return Math.abs(MoPrefs.getShooterPIDSetpoint() - shooterEncoder.getVelocity()) < MoPrefs
-        .getShooterFlywheelTolerance();
+    return Math.abs(MoPrefs.get(MoPrefsKey.SHOOTER_PID_SETPOINT) - shooterEncoder.getVelocity()) < MoPrefs
+        .get(MoPrefsKey.SHOOTER_FLYWHEEL_TOLERANCE);
   }
 
   private void updatePIDConstants() {

--- a/src/main/java/frc/robot/subsystems/StorageSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/StorageSubsystem.java
@@ -8,6 +8,7 @@ import edu.wpi.first.wpilibj.VictorSP;
 import frc.robot.Constants;
 import frc.robot.utils.MoPrefs;
 import frc.robot.utils.SafeSP;
+import frc.robot.utils.MoPrefs.MoPrefsKey;
 
 public class StorageSubsystem extends SubsystemBase {
 
@@ -26,11 +27,11 @@ public class StorageSubsystem extends SubsystemBase {
   }
 
   public void run() {
-    storage.set(MoPrefs.getStorageSpeed());
+    storage.set(MoPrefs.get(MoPrefsKey.STORAGE_SPEED));
   }
 
   public void reverse() {
-    speed = -MoPrefs.getStorageSpeed();
+    speed = -MoPrefs.get(MoPrefsKey.STORAGE_SPEED);
     storage.set(speed);
   }
 

--- a/src/main/java/frc/robot/utils/MoPrefs.java
+++ b/src/main/java/frc/robot/utils/MoPrefs.java
@@ -3,17 +3,57 @@ package frc.robot.utils;
 import edu.wpi.first.wpilibj.Preferences;
 
 public class MoPrefs {
-  static final double INTAKE_ROLLER_SETPOINT = 0.125;
-  static final double INTAKE_ROLLER_ACC_RAMP = 0.1;
-  static final int CLIMBER_ENCODER_LIMIT = 10;
-  static final double SHOOTER_HOOD_SETPOINT = 100;
-  static final double SHOOTER_HOOD_POSITION_TOLERANCE = 2;
-  static final double SHOOTER_GATE_SETPOINT = 1;
-  static final double SHOOTER_PID_SETPOINT = 4500;
-  static final double STORAGE_SPEED = 0.75;
-  static final double SHOOTER_FLYWHEEL_TOLERANCE = 100; // RPM
-  static final double SHOOT_FROM_WALL_HOOD_SETPOINT = 60; // The encoder setpoint that will reliably hit the Outer Port
-                                                          // when the robot is sitting up against the Power Port.
+
+  public static enum MoPrefsKey {
+    INTAKE_ROLLER_SETPOINT(0.125),
+
+    INTAKE_ROLLER_ACC_RAMP(0.1),
+
+    CLIMBER_ENCODER_LIMIT(10),
+
+    SHOOTER_HOOD_SETPOINT(100),
+
+    // FIXME: Copy this value to the new key
+    // The original key for this value was "SHOOTER_HOOD_POS_TOLERANCE"
+    // The new key is "SHOOTER_HOOD_POSITION_TOLERANCE"
+    SHOOTER_HOOD_POSITION_TOLERANCE(2),
+
+    SHOOTER_GATE_SETPOINT(1),
+
+    // FIXME: Copy this value to the new key
+    // The original key for this value was "Shooter PID Setpoint"
+    // The new key is "SHOOTER_PID_SETPOINT"
+    SHOOTER_PID_SETPOINT(4500),
+
+    STORAGE_SPEED(0.75),
+
+    // FIXME: Copy this value to the new key
+    // The original key for this value was "FLYWHEEL_TOLER"
+    // The new key is "SHOOTER_FLYWHEEL_TOLERANCE"
+    SHOOTER_FLYWHEEL_TOLERANCE(100), // RPM
+
+    // The encoder setpoint that will reliably hit the Outer Port
+    // when the robot is sitting up against the Power Port.
+    //
+    // FIXME: Copy this value to the new key
+    // The original key for this value was "Shoot From Wall Hood Setpoint"
+    // The new key is "SHOOT_FROM_WALL_HOOD_SETPOINT"
+    SHOOT_FROM_WALL_HOOD_SETPOINT(60);
+
+    private double defaultValue;
+
+    MoPrefsKey(double defaultValue) {
+      this.defaultValue = defaultValue;
+    }
+
+    public String getPrefsKey() {
+      return this.name();
+    }
+
+    public double getDefaultValue() {
+      return defaultValue;
+    }
+  }
 
   // PID constants for the shooter flywheel
   static final double SHOOTER_KP = 0.00005;
@@ -70,44 +110,12 @@ public class MoPrefs {
     System.out.format("set pref: %s=%f\n", key, value);
   }
 
-  public static double getIntakeRollerSetpoint() {
-    return getDouble("INTAKE_ROLLER_SETPOINT", INTAKE_ROLLER_SETPOINT);
+  public static double get(MoPrefsKey key) {
+    return getDouble(key.getPrefsKey(), key.getDefaultValue());
   }
 
-  public static double getClimberEncoderLimit() {
-    return getDouble("CLIMBER_ENCODER_LIMIT", CLIMBER_ENCODER_LIMIT);
-  }
-
-  public static double getShooterHoodSetpoint() {
-    return getDouble("SHOOTER_HOOD_SETPOINT", SHOOTER_HOOD_SETPOINT);
-  }
-
-  public static double getShooterHoodPositionTolerance() {
-    return getDouble("SHOOTER_HOOD_POS_TOLERANCE", SHOOTER_HOOD_POSITION_TOLERANCE);
-  }
-
-  public static double getShooterGateSetpoint() {
-    return getDouble("SHOOTER_GATE_SETPOINT", SHOOTER_GATE_SETPOINT);
-  }
-
-  public static double getIntakeRollerAccRamp() {
-    return getDouble("INTAKE_ROLLER_ACC_RAMP", INTAKE_ROLLER_ACC_RAMP);
-  }
-
-  public static double getStorageSpeed() {
-    return getDouble("STORAGE_SPEED", STORAGE_SPEED);
-  }
-
-  public static double getShooterFlywheelTolerance() {
-    return getDouble("FLYWHEEL_TOLER", SHOOTER_FLYWHEEL_TOLERANCE);
-  }
-
-  public static double getShooterPIDSetpoint() {
-    return getDouble("Shooter PID Setpoint", SHOOTER_PID_SETPOINT);
-  }
-
-  public static double getShootFromWallHoodSetpoint() {
-    return getDouble("Shoot From Wall Hood Setpoint", SHOOT_FROM_WALL_HOOD_SETPOINT);
+  public static void set(MoPrefsKey key, double value) {
+    setDouble(key.getPrefsKey(), value);
   }
 
   public static double getShooterKP() {

--- a/src/main/java/frc/robot/utils/MoPrefs.java
+++ b/src/main/java/frc/robot/utils/MoPrefs.java
@@ -38,7 +38,43 @@ public class MoPrefs {
     // FIXME: Copy this value to the new key
     // The original key for this value was "Shoot From Wall Hood Setpoint"
     // The new key is "SHOOT_FROM_WALL_HOOD_SETPOINT"
-    SHOOT_FROM_WALL_HOOD_SETPOINT(60);
+    SHOOT_FROM_WALL_HOOD_SETPOINT(60),
+
+    SHOOTER_KP(0.00005),
+
+    SHOOTER_KI(0.000001),
+
+    SHOOTER_KD(0),
+
+    SHOOTER_KIZ(0.0000001),
+
+    SHOOTER_KFF(0.00000156),
+
+    // PID constants for the drivetrain
+    DRIVE_KP(0.00005),
+
+    DRIVE_KI(0.000001),
+
+    DRIVE_KD(0),
+
+    DRIVE_KIZ(0.0000001),
+
+    DRIVE_KFF(0.00000156),
+
+    // PID constants for the shooter hood
+    HOOD_KP(0.15),
+
+    HOOD_KI(1e-6),
+
+    HOOD_KD(0),
+
+    HOOD_KIZ(0),
+
+    HOOD_KFF(0),
+
+    HOOD_ALLOWED_ERR(2),
+
+    HOOD_OUT_RANGE(1);
 
     private double defaultValue;
 
@@ -54,29 +90,6 @@ public class MoPrefs {
       return defaultValue;
     }
   }
-
-  // PID constants for the shooter flywheel
-  static final double SHOOTER_KP = 0.00005;
-  static final double SHOOTER_KI = 0.000001;
-  static final double SHOOTER_KD = 0;
-  static final double SHOOTER_KIZ = 0.0000001;
-  static final double SHOOTER_KFF = 0.00000156;
-
-  // PID constants for the drivetrain
-  static final double DRIVE_KP = 0.00005;
-  static final double DRIVE_KI = 0.000001;
-  static final double DRIVE_KD = 0;
-  static final double DRIVE_KIZ = 0.0000001;
-  static final double DRIVE_KFF = 0.00000156;
-
-  // PID constants for the shooter hood
-  static final double HOOD_KP = 0.15;
-  static final double HOOD_KI = 1e-6;
-  static final double HOOD_KD = 0;
-  static final double HOOD_KIZ = 0;
-  static final double HOOD_KFF = 0;
-  static final double HOOD_ALLOWED_ERR = 2;
-  static final double HOOD_OUT_RANGE = 1;
 
   private MoPrefs() {
     throw new IllegalStateException("MoPrefs should be static");
@@ -116,73 +129,5 @@ public class MoPrefs {
 
   public static void set(MoPrefsKey key, double value) {
     setDouble(key.getPrefsKey(), value);
-  }
-
-  public static double getShooterKP() {
-    return getDouble("SHOOTER_KP", SHOOTER_KP);
-  }
-
-  public static double getShooterKI() {
-    return getDouble("SHOOTER_KI", SHOOTER_KI);
-  }
-
-  public static double getShooterKD() {
-    return getDouble("SHOOTER_KD", SHOOTER_KD);
-  }
-
-  public static double getShooterKIZ() {
-    return getDouble("SHOOTER_KIZ", SHOOTER_KIZ);
-  }
-
-  public static double getShooterKFF() {
-    return getDouble("SHOOTER_KFF", SHOOTER_KFF);
-  }
-
-  public static double getDriveKP() {
-    return getDouble("DRIVE_KP", DRIVE_KP);
-  }
-
-  public static double getDriveKI() {
-    return getDouble("DRIVE_KI", DRIVE_KI);
-  }
-
-  public static double getDriveKD() {
-    return getDouble("DRIVE_KD", DRIVE_KD);
-  }
-
-  public static double getDriveKIZ() {
-    return getDouble("DRIVE_KIZ", DRIVE_KIZ);
-  }
-
-  public static double getDriveKFF() {
-    return getDouble("DRIVE_KFF", DRIVE_KFF);
-  }
-
-  public static double getHoodKP() {
-    return getDouble("HOOD_KP", HOOD_KP);
-  }
-
-  public static double getHoodKI() {
-    return getDouble("HOOD_KI", HOOD_KI);
-  }
-
-  public static double getHoodKD() {
-    return getDouble("HOOD_KD", HOOD_KD);
-  }
-
-  public static double getHoodKIZ() {
-    return getDouble("HOOD_KIZ", HOOD_KIZ);
-  }
-
-  public static double getHoodKFF() {
-    return getDouble("HOOD_KFF", HOOD_KFF);
-  }
-
-  public static double getHoodAllowedErr() {
-    return getDouble("HOOD_ALLOWED_ERR", HOOD_ALLOWED_ERR);
-  }
-
-  public static double getHoodOutRange() {
-    return getDouble("HOOD_OUT_RANGE", HOOD_OUT_RANGE);
   }
 }


### PR DESCRIPTION
MoPrefs are now accessed using the get() method, which takes a MoPrefsKey.
MoPrefsKeys are responsible for tracking the default value of their
associated preference, and are used as keys into the Preferences table.

This improves maintainability: adding a new preference only requires
adding a new entry to the MoPrefsKey enum instead of a whole new method
on MoPrefs.

See https://github.com/momentumfrc/2020InfiniteRecharge/pull/26#discussion_r568976978